### PR TITLE
This PR adds a unit test to test for the entity given as a sample.

### DIFF
--- a/caliper_sender.py
+++ b/caliper_sender.py
@@ -145,6 +145,8 @@ def get_caliper_event(event, event_type, event_action):
     # It's possible to not have chapters if it's a top level. This would result in -3 being 'published'
     if not event.get('div_id'):
         return None
+    # This will split paths like /srv/web2py/applications/runestone/books/thinkcspy/published/thinkcspy/GeneralIntro/Algorithms.html
+    # See the unit test code in the tests directory for more examples
     nav_path = event.get('div_id').split('/')
     if len(nav_path) < 3:
         return None

--- a/caliper_sender.py
+++ b/caliper_sender.py
@@ -187,7 +187,7 @@ def get_caliper_event(event, event_type, event_action):
     edapp_id = os.getenv("EDAPP_ID")
     if not course_id or not edapp_id:
         raise Exception("You need to define both EDAPP_ID and COURSE_ID before using this.")
-    organization = caliper.entities.Organization(id="urn:course_offering_id" + course_id)
+    organization = caliper.entities.Organization(id="urn:course_offering_id:" + course_id)
     edApp = caliper.entities.SoftwareApplication(id="url:edapp_id:" + edapp_id)
     the_event = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,15 @@
-aniso8601==4.1.0
+aniso8601==6.0.0
 certifi==2018.11.29
 chardet==3.0.4
 python-decouple>=3.1,<3.99
 python-dotenv==0.10.1
 future==0.17.1
-future-fstrings==0.4.5
+future-fstrings
 idna==2.8
--e git+https://github.com/IMSGlobal/caliper-python.git@0a43809e244bb86c2370b08c3db5634dbbd28cac#egg=imsglobal_caliper
+-e git+https://github.com/IMSGlobal/caliper-python.git@a8549ae7227cef896f222626ffd15c4ef4bf9edf#egg=imsglobal-caliper
 psycopg2==2.7.7
 requests==2.21.0
-rfc3986==1.1.0
+rfc3986==1.3.2
 tokenize-rt==2.1.0
 urllib3==1.24.2
+python-dateutil==2.8.1

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -1,0 +1,38 @@
+import os, sys, unittest
+
+import caliper
+
+from dateutil.parser import parse
+
+# Add this path first so it picks up the newest changes without having to rebuild
+this_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, this_dir + "/..")
+import caliper_sender as cs
+
+class TestSender(unittest.TestCase):
+    def test_get_caliper_event_chapter(self):
+        event = {
+            "div_id": "/srv/web2py/applications/runestone/books/thinkcspy/published/thinkcspy/GeneralIntro/Algorithms.html", 
+            "sid": "test",
+            "timestamp": parse("2020-01-16 17:24:50")
+        }
+        event = cs.get_caliper_event(event, "ViewEvent", "Viewed")
+        self.assertTrue(isinstance(event, caliper.events.ViewEvent))
+        self.assertTrue(isinstance(event.object, caliper.entities.Page))
+        self.assertTrue(isinstance(event.object.isPartOf, caliper.entities.Chapter))
+        self.assertTrue(isinstance(event.object.isPartOf.isPartOf, caliper.entities.Document))
+
+    def test_get_caliper_event_document(self):
+        event = {
+            "div_id": "/opt/web2py/applications/runestone/books/fopp/published/fopp/index.html", 
+            "sid": "test",
+            "timestamp": parse("2020-01-16 17:24:50")
+        }
+        event = cs.get_caliper_event(event, "ViewEvent", "Viewed")
+        self.assertTrue(isinstance(event, caliper.events.ViewEvent))
+        self.assertTrue(isinstance(event.object, caliper.entities.Page))
+        self.assertTrue(isinstance(event.object.isPartOf, caliper.entities.Document))
+        self.assertTrue(event.object.isPartOf.isPartOf == None)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
It also switches to reading from the back of the div_id rather than
the front

It also updates a few libraries.

Entity ID's are valid now (using file:/ and urn:) where it wasn't using
this before and may have been rejected

If the page is at the top level also there is no chapter added